### PR TITLE
bitnami/keycloak 16.1.6 (Keycloak 22)

### DIFF
--- a/keycloak/README.md
+++ b/keycloak/README.md
@@ -20,8 +20,7 @@ sed -i 's/%K8S_HOSTNAME%/<k8s-hostname>/g' jupyterhub.yml keycloak.yml
 Install Keycloak with a default admin user
 
 ```
-helm repo add bitnami https://charts.bitnami.com/bitnami
-helm upgrade --install keycloak bitnami/keycloak --version=10.1.0 -f keycloak.yml --wait
+helm upgrade --install keycloak oci://registry-1.docker.io/bitnamicharts/keycloak --version=16.1.6 -f keycloak.yml --wait
 ```
 
 Use the [python-keycloak](https://github.com/marcospereirampj/python-keycloak) module to create a user and OAuth client.

--- a/keycloak/jupyterhub.yml
+++ b/keycloak/jupyterhub.yml
@@ -12,6 +12,8 @@ hub:
       authorize_url: http://%K8S_HOSTNAME%/keycloak/realms/master/protocol/openid-connect/auth
       token_url: http://%K8S_HOSTNAME%/keycloak/realms/master/protocol/openid-connect/token
       userdata_url: http://%K8S_HOSTNAME%/keycloak/realms/master/protocol/openid-connect/userinfo
+      scope:
+        - openid
       login_service: keycloak
       username_key: preferred_username
       userdata_params:

--- a/keycloak/keycloak.yml
+++ b/keycloak/keycloak.yml
@@ -4,7 +4,8 @@ image:
   debug: true
 
 extraEnvVars:
-  - name: KEYCLOAK_LOG_LEVEL
+  # For debugging only
+  - name: KC_LOG_LEVEL
     value: ALL
 
 auth:


### PR DESCRIPTION
The `openid` scope must now be explicitly passed.