### PR TITLE
run_codeblocks.py: flush print

### DIFF
--- a/ci/run_codeblocks.py
+++ b/ci/run_codeblocks.py
@@ -30,6 +30,6 @@ with open(args.input) as f:
             code.append(line)
 
 for c in code:
-    print(f"Running {c}")
+    print(f"Running {c}", flush=True)
     if args.run:
         run(c, shell=True, check=True)


### PR DESCRIPTION
Hopefully this ensures the print statements appear in the right place in the GitHub workflow logs