### PR TITLE
Configure keycloak with client roles for users and admins

### DIFF
--- a/keycloak/README.md
+++ b/keycloak/README.md
@@ -1,4 +1,6 @@
-# Keycloak
+# Keycloak with custom roles
+
+The spins up a Keycloak server, and creates custom roles for managing JupyterHub admins and users in Keycloak.
 
 ## Prerequisites
 
@@ -23,13 +25,14 @@ Install Keycloak with a default admin user
 helm upgrade --install keycloak oci://registry-1.docker.io/bitnamicharts/keycloak --version=24.1.0 -f keycloak.yml --wait
 ```
 
-Use the [python-keycloak](https://github.com/marcospereirampj/python-keycloak) module to create a user and OAuth client.
+Use the [python-keycloak](https://github.com/marcospereirampj/python-keycloak) module to create a user and OAuth client and roles that can be used to define Jupyterhub users and admins.
+See the [`setup-keycloak.py`](setup-keycloak.py) script for details, along with [`jupyterhub.yml`](./jupyterhub.yml) for the matching JupyterHub configuration.
 
 ```
 python3 -mvenv ./venv
 . ./venv/bin/activate
 pip install python-keycloak
-python setup-keycloak.py --external-host http://<k8s-hostname>
+python setup-keycloak.py --keycloak-url=http://<k8s-hostname>/keycloak/ --jupyterhub-url=http://<k8s-hostname>/jupyter/
 ```
 
 ## JupyterHub

--- a/keycloak/jupyterhub.yml
+++ b/keycloak/jupyterhub.yml
@@ -14,11 +14,22 @@ hub:
       userdata_url: http://%K8S_HOSTNAME%/keycloak/realms/master/protocol/openid-connect/userinfo
       scope:
         - openid
+        # The custom scope name
+        - jupyterhub-roles
       login_service: keycloak
       username_key: preferred_username
       userdata_params:
         state: state
-      allow_all: true
+      # The location of the custom Keycloak field in the userdata response
+      auth_state_groups_key: oauth_user.jupyterhub.roles
+      # JupyterHub defers to Keycloak for all group memberships
+      manage_groups: true
+      allowed_groups:
+        # The Keycloak role for JupyterHub users
+        - jupyterhub-users
+      admin_groups:
+        # The Keycloak role for JupyterHub admins
+        - jupyterhub-admins
     JupyterHub:
       authenticator_class: generic-oauth
 

--- a/keycloak/setup-keycloak.py
+++ b/keycloak/setup-keycloak.py
@@ -2,26 +2,68 @@
 # coding: utf-8
 # https://github.com/marcospereirampj/python-keycloak
 from argparse import ArgumentParser
+import json
 from keycloak import KeycloakAdmin
+import sys
 
 parser = ArgumentParser()
-parser.add_argument("--external-host", default="http://localhost:8080")
-parser.add_argument("--keycloak-url", default="{external_host}/keycloak/")
-parser.add_argument("--jupyterhub-url", default="{external_host}/jupyter/")
-parser.add_argument("--keycloak-admin", default="admin")
-parser.add_argument("--keycloak-password", default="admin")
-parser.add_argument("--user", default="example@example.com")
-parser.add_argument("--password", default="secret")
-parser.add_argument("--firstname", default="Example")
-parser.add_argument("--lastname", default="User")
-parser.add_argument("--client", default="jupyterhub")
-parser.add_argument("--client-secret", default="jupyterhub-client-secret")
+parser.add_argument(
+    "--keycloak-url", default="http://localhost:8080", help="Keycloak URL"
+)
+parser.add_argument(
+    "--jupyterhub-url", default="http://localhost:8000", help="JupyterHub URL"
+)
+parser.add_argument("--keycloak-admin", default="admin", help="Keycloak admin user")
+parser.add_argument(
+    "--keycloak-password", default="admin", help="Keycloak admin password"
+)
+parser.add_argument(
+    "--user", default="example@example.com", help="Username of new user"
+)
+parser.add_argument("--password", default="secret", help="Password for new user")
+parser.add_argument("--firstname", default="Example", help="First name of new user")
+parser.add_argument("--lastname", default="User", help="Last name of new user")
+parser.add_argument(
+    "--client-name", default="jupyterhub", help="JupyterHub OAuth client name"
+)
+parser.add_argument(
+    "--client-secret",
+    default="jupyterhub-client-secret",
+    help="JupyterHub OAuth client secret",
+)
+parser.add_argument(
+    "--admin-role",
+    default="jupyterhub-admins",
+    help="Name of JupyterHub Keycloak admin role",
+)
+parser.add_argument(
+    "--user-role",
+    default="jupyterhub-users",
+    help="Name of JupyterHub Keycloak user role",
+)
+parser.add_argument(
+    "--scope-name",
+    default="jupyterhub-roles",
+    help="Custom scope name to use for JupyterHub Keycloak roles",
+)
 
 args = parser.parse_args()
-jupyterhub_url = args.jupyterhub_url.format(external_host=args.external_host)
+
+
+def output(firstline, message=None):
+    if sys.stdout.isatty():
+        # Bold green text
+        print(f"\033[1m\033[32m{firstline}\033[97m\033[0m")
+    else:
+        print(firstline)
+    if message is not None:
+        print(json.dumps(message, indent=2))
+
+
+jupyterhub_url = args.jupyterhub_url
 
 keycloak_admin = KeycloakAdmin(
-    server_url=args.keycloak_url.format(external_host=args.external_host),
+    server_url=args.keycloak_url,
     username=args.keycloak_admin,
     password=args.keycloak_password,
     realm_name="master",
@@ -33,8 +75,8 @@ user_payload = {
     "email": args.user,
     "username": args.user,
     "enabled": True,
-    "firstName": "Example",
-    "lastName": "User",
+    "firstName": args.firstname,
+    "lastName": args.lastname,
     "credentials": [
         {
             "value": args.password,
@@ -44,27 +86,91 @@ user_payload = {
 }
 uid = keycloak_admin.get_user_id(args.user)
 if uid:
-    print(f"Updating user {args.user} ({uid}) {user_payload}")
+    output(f"Updating user {args.user} ({uid})", user_payload)
     keycloak_admin.update_user(uid, user_payload)
 else:
-    print(f"Creating user {args.user} {user_payload}")
+    output(f"Creating user {args.user}", user_payload)
     keycloak_admin.create_user(user_payload)
 
 # Create an OAuth client for JupyterHub
 client_payload = {
-    "clientId": args.client,
-    "name": args.client,
-    "redirectUris": [
-        args.jupyterhub_url.format(external_host=args.external_host)
-        + "hub/oauth_callback"
-    ],
+    "clientId": args.client_name,
+    "name": args.client_name,
+    "rootUrl": args.jupyterhub_url.rstrip("/"),
+    "baseUrl": "/",
+    "redirectUris": ["/hub/oauth_callback"],
     "clientAuthenticatorType": "client-secret",
     "secret": args.client_secret,
 }
-cid = keycloak_admin.get_client_id(args.client)
+cid = keycloak_admin.get_client_id(args.client_name)
 if cid:
-    print(f"Updating client {args.client} ({cid}) {client_payload}")
+    output(f"Updating client {args.client_name} ({cid})", client_payload)
     keycloak_admin.update_client(cid, client_payload)
 else:
-    print(f"Creating client {args.client} {client_payload}")
-    keycloak_admin.create_client(client_payload)
+    output(f"Creating client {args.client_name}", client_payload)
+    cid = keycloak_admin.create_client(client_payload)
+# print(keycloak_admin.get_client(cid))
+
+# Create some client specific roles (you could also create realm roles that can be used by multiple clients)
+client_role_admins_payload = {
+    "name": args.admin_role,
+    "description": "JupyterHub admins",
+}
+output(f"Creating/updating client role {args.admin_role}", client_role_admins_payload)
+keycloak_admin.create_client_role(cid, client_role_admins_payload, skip_exists=True)
+client_role_users_payload = {
+    "name": args.user_role,
+    "description": "JupyterHub users",
+}
+output(f"Creating/updating client role {args.user_role}", client_role_users_payload)
+keycloak_admin.create_client_role(cid, client_role_users_payload, skip_exists=True)
+
+# Create or update a custom scope called "jupyterhub-groups" that maps Keycloak client Roles
+scope = {
+    "name": args.scope_name,
+    "description": "JupyterHub Keycloak roles",
+    "protocol": "openid-connect",
+    "protocolMappers": [
+        {
+            "name": args.scope_name,
+            "protocol": "openid-connect",
+            # Map client roles:
+            "protocolMapper": "oidc-usermodel-client-role-mapper",
+            # Map realm roles:
+            # "protocolMapper": "oidc-usermodel-realm-role-mapper",
+            # Map Keycloak groups:
+            # "protocolMapper": "oidc-group-membership-mapper",
+            "config": {
+                "multivalued": "true",
+                # Include in the userinfo response
+                "userinfo.token.claim": "true",
+                # The userinfo field
+                "claim.name": "jupyterhub.roles",
+                "jsonType.label": "String",
+                # Only return client scopes for jupyterhub
+                "usermodel.clientRoleMapping.clientId": args.client_name,
+            },
+        }
+    ],
+}
+output(f"Creating or updating scope {args.scope_name}", scope)
+scope_id = keycloak_admin.create_client_scope(scope, skip_exists=True)
+keycloak_admin.update_client_scope(scope_id, scope)
+
+# Add scope to client
+keycloak_admin.add_client_optional_client_scope(cid, scope_id, {})
+
+# Assign users to client roles
+client_admin_role = keycloak_admin.get_client_role(cid, args.admin_role)
+client_user_role = keycloak_admin.get_client_role(cid, args.user_role)
+
+admin_uid = keycloak_admin.get_user_id(args.keycloak_admin)
+output(
+    f"Assigning roles to admin {args.keycloak_admin } ({admin_uid})",
+    [client_admin_role, client_user_role],
+)
+keycloak_admin.assign_client_role(admin_uid, cid, [client_admin_role, client_user_role])
+
+user_uid = keycloak_admin.get_user_id(args.user)
+output(f"Assigning roles to user {args.user} ({user_uid})", client_user_role)
+keycloak_admin.assign_client_role(user_uid, cid, [client_user_role])

--- a/keycloak/tests/test_jupyterhub_keycloak.py
+++ b/keycloak/tests/test_jupyterhub_keycloak.py
@@ -2,6 +2,7 @@
 # https://playwright.dev/python/docs/test-runners
 #
 # pytest --browser firefox --base-url http://%K8S_HOSTNAME% [--headed --slowmo 1000]
+import json
 
 
 def test_browser(page):
@@ -23,3 +24,29 @@ def test_browser(page):
 
     # Server should be spawned, and should be redirected to JupyterLab
     page.wait_for_url("/jupyter/user/example@example.com/lab")
+
+
+def test_admin(page):
+    # Go to <base-url>/jupyter/hub/home, wait for redirect to login page
+    page.goto("/jupyter/hub/home")
+    page.wait_for_selector("text=Sign in with keycloak")
+
+    # Click "Sign in with keycloak", wait for redirect to keycloak
+    page.locator("text=Sign in with keycloak").click()
+    page.wait_for_url("/keycloak/realms/master/protocol/openid-connect/auth?*")
+
+    # Fill username and password
+    page.locator('input[name="username"]').fill("admin")
+    page.locator('input[name="password"]').fill("admin")
+
+    # Click "Sign In"
+    page.locator('button:has-text("Sign In")').click()
+
+    # Should be redirected to /hub/home
+    page.wait_for_url("/jupyter/hub/home")
+
+    # List all groups via API, should match the Keycloak roles
+    page.goto("/jupyter/hub/api/groups")
+    content = page.locator("body").text_content()
+    groups = json.loads(content)
+    assert set(g["name"] for g in groups) == {"jupyterhub-admins", "jupyterhub-users"}


### PR DESCRIPTION
A variant of https://z2jh.jupyter.org/en/4.0.0/administrator/authentication.html#keycloak
using Keycloak client roles for users and admins.